### PR TITLE
Update pubspec.lock to use linalg 0.4.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       name: linalg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2"
+    version: "0.4.0"
   matcher:
     dependency: transitive
     description:


### PR DESCRIPTION
linalg is null safe starting with 0.4.0